### PR TITLE
Incorporate no_docs_url option and update CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
           upload_values: true
           upload_metadata: true
           display_level: error
+          no_docs_url: true
           ansible_version: 2.13
         env:
           SPOTTER_USERNAME: ${{ secrets.SPOTTER_USERNAME }}
@@ -32,6 +33,7 @@ jobs:
         with:
           paths: tests/playbook-no-errors.yml
           ansible_version: 2.13
+          display_level: error
         env:
           SPOTTER_USERNAME: ${{ secrets.SPOTTER_USERNAME }}
           SPOTTER_PASSWORD: ${{ secrets.SPOTTER_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The action accepts the following inputs:
 | `upload_values`   | no       | false   | Parses and uploads values from Ansible task parameters to the backend.                                                                                                             |                                
 | `upload_metadata` | no       | false   | Uploads metadata (i.e., file names, line and column numbers) to the backend.                                                                                                       |                                
 | `display_level`   | no       | hint    | Displays check results with specified level or greater (e.g., warning will show all warnings and errors, but suppress hints). Available options: hint, warning, error.             |
+| `no_docs_url`     | no       | false   | Omits documentation URLs from the output.                                                                                                                                          |  
 | `ansible_version` | no       | /       | Ansible version to use for scanning. If not specified, all Ansible versions are considered for scanning.                                                                           |
 
 ### Outputs
@@ -94,6 +95,7 @@ jobs:
           upload_values: true
           upload_metadata: true
           display_level: error
+          no_docs_url: true
           ansible_version: 2.13
         env:
           SPOTTER_USERNAME: ${{ secrets.SPOTTER_USERNAME }}

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Displays check results with specified level or greater (e.g., warning will show all warnings and errors, but suppress hints). Available options: hint, warning, error."
     required: false
     default: "hint"
+  no_docs_url:
+    description: "Omits documentation URLs from the output."
+    required: false
+    default: "false"
   ansible_version:
     description: "Ansible version to use for scanning. If not specified, all Ansible versions are considered for scanning."
     required: false
@@ -39,4 +43,5 @@ runs:
     - ${{ inputs.upload_values }}
     - ${{ inputs.upload_metadata }}
     - ${{ inputs.display_level }}
+    - ${{ inputs.no_docs_url }}
     - ${{ inputs.ansible_version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,8 @@ project_id="$2"
 upload_values="$3"
 upload_metadata="$4"
 display_level="$5"
-ansible_version="$6"
+no_docs_url="$6"
+ansible_version="$7"
 
 buildScanCLICommand() {
   scan_command="spotter scan"
@@ -25,6 +26,10 @@ buildScanCLICommand() {
 
   if [ -n "$display_level" ]; then
     scan_command="${scan_command} --display-level ${display_level}"
+  fi
+
+  if [ "$no_docs_url" = "true" ]; then
+    scan_command="${scan_command} --no-docs-url"
   fi
 
   if [ -n "$ansible_version" ]; then


### PR DESCRIPTION
This PR adds `--no-docs-url` and updates CI integration tests accordingly.