### PR TITLE
Update Spotter CLI Docker image and tag to 1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/spotter-cli:main
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.1.1
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
This change updates the Steampunk Spotter CLI image to point to https://gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli/container_registry/3453459 and tags version to `1.1.1`.