### PR TITLE
Bump CLI Docker image to 1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.1.10
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.2.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
Updating the CLI Docker image to `1.2.0`.