### PR TITLE
CLI to 1.2.6 - option renaming, scan profiles, custom policies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,12 @@ jobs:
         uses: ./
         with:
           paths: tests/playbook-with-errors.yml
-          upload_values: true
-          upload_metadata: true
+          include_values: true
+          include_metadata: true
           display_level: error
           no_docs_url: true
           ansible_version: 2.14
+          profile: full
         env:
           SPOTTER_API_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
         continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.2.1
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.2.6
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub Action for scanning your Ansible content with [Steampunk Spotter].
 - [Acknowledgement](#acknowledgement)
 
 ## Introduction
-[Steampunk Spotter] provides an Assisted Automation Writing tool that analyzes
+[Steampunk Spotter] provides an Ansible Playbook Scanning Tool that analyzes
 and offers recommendations for your Ansible Playbooks.
 This GitHub Action allows you to use [steampunk-spotter] CLI within GitHub
 CI/CD workflows.
@@ -36,15 +36,18 @@ steps:
 ### Inputs
 The action accepts the following inputs:
 
-| Name              | Required | Default | Description                                                                                                                                                                        |
-|-------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `paths`           | no       | .       | List of paths to Ansible content files to be scanned. If not specified, the whole repository is scanned.                                                                           |
-| `project_id`      | no       | /       | ID of an existing target project in the app, where the scan result will be stored. If not specified, the first project of the user's first organization (in the app) will be used. |
-| `upload_values`   | no       | false   | Parses and uploads values from Ansible task parameters to the backend.                                                                                                             |                                
-| `upload_metadata` | no       | false   | Uploads metadata (i.e., file names, line and column numbers) to the backend.                                                                                                       |                                
-| `display_level`   | no       | hint    | Displays check results with specified level or greater (e.g., warning will show all warnings and errors, but suppress hints). Available options: hint, warning, error.             |
-| `no_docs_url`     | no       | false   | Omits documentation URLs from the output.                                                                                                                                          |  
-| `ansible_version` | no       | /       | Ansible version to use for scanning. If not specified, all Ansible versions are considered for scanning.                                                                           |
+| Name                    | Required | Default | Description                                                                                                                                                                        |
+|-------------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `paths`                 | no       | .       | List of paths to Ansible content files to be scanned. If not specified, the whole repository is scanned.                                                                           |
+| `project_id`            | no       | /       | ID of an existing target project in the app, where the scan result will be stored. If not specified, the first project of the user's first organization (in the app) will be used. |
+| `upload_values`         | no       | false   | Parses and uploads values from Ansible task parameters to the backend.                                                                                                             |                                
+| `upload_metadata`       | no       | false   | Uploads metadata (i.e., file names, line and column numbers) to the backend.                                                                                                       |                                
+| `display_level`         | no       | hint    | Displays check results with specified level or greater (e.g., warning will show all warnings and errors, but suppress hints). Available options: hint, warning, error.             |
+| `no_docs_url`           | no       | false   | Omits documentation URLs from the output.                                                                                                                                          |  
+| `ansible_version`       | no       | /       | Ansible version to use for scanning. If not specified, all Ansible versions are considered for scanning.                                                                           |
+| `profile`               | no       | /       | Sets profile with selected set of checks to be used for scanning.                                                                                                                  |
+| `custom_policies_path`  | no       | /       | Path to the file or folder with custom OPA policies written in Rego Language (enterprise feature).                                                                                 |
+| `custom_policies_clear` | no       | /       | Clears OPA policies for custom Spotter checks after scanning (enterprise feature).                                                                                                 |
 
 ### Outputs
 The action produces the following outputs:
@@ -96,11 +99,12 @@ jobs:
         uses: xlab-steampunk/spotter-action@<version>
         with:
           paths: playbook.yaml
-          upload_values: true
-          upload_metadata: true
+          include_values: true
+          include_metadata: true
           display_level: error
           no_docs_url: true
           ansible_version: 2.14
+          profile: full
         env:
           SPOTTER_API_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,13 @@ inputs:
     description: "Sets profile with selected set of checks to be used for scanning."
     required: false
     default: "default"
+  custom_policies_path:
+    description: "Path to the file or folder with custom OPA policies written in Rego Language (enterprise feature)."
+    required: false
+  custom_policies_clear:
+    description: "Clears OPA policies for custom Spotter checks after scanning (enterprise feature)."
+    required: false
+    default: "false"
 outputs:
   output:
     description: "Output from scanning (from spotter scan CLI command)."
@@ -50,3 +57,5 @@ runs:
     - ${{ inputs.no_docs_url }}
     - ${{ inputs.ansible_version }}
     - ${{ inputs.profile }}
+    - ${{ inputs.custom_policies_path }}
+    - ${{ inputs.custom_policies_clear }}

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
   project_id:
     description: "ID of an existing target project in the app, where the scan result will be stored. If not specified, the first project of the user's first organization (in the app) will be used."
     required: false
-  upload_values:
+  include_values:
     description: "Parses and uploads values from Ansible task parameters to the backend."
     required: false
     default: "false"
-  upload_metadata:
+  include_metadata:
     description: "Uploads metadata (i.e., file names, line and column numbers) to the backend."
     required: false
     default: "false"
@@ -31,6 +31,10 @@ inputs:
   ansible_version:
     description: "Ansible version to use for scanning. If not specified, all Ansible versions are considered for scanning."
     required: false
+  profile:
+    description: "Sets profile with selected set of checks to be used for scanning."
+    required: false
+    default: "default"
 outputs:
   output:
     description: "Output from scanning (from spotter scan CLI command)."
@@ -40,8 +44,9 @@ runs:
   args:
     - ${{ inputs.paths }}
     - ${{ inputs.project_id }}
-    - ${{ inputs.upload_values }}
-    - ${{ inputs.upload_metadata }}
+    - ${{ inputs.include_values }}
+    - ${{ inputs.include_metadata }}
     - ${{ inputs.display_level }}
     - ${{ inputs.no_docs_url }}
     - ${{ inputs.ansible_version }}
+    - ${{ inputs.profile }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,29 @@ display_level="$5"
 no_docs_url="$6"
 ansible_version="$7"
 profile="$8"
+custom_policies_path="$9"
+custom_policies_clear="${10}"
+
+# helper functions for building CLI commands
+buildSetPoliciesCommand() {
+  set_policies_command="spotter set-policies"
+
+  if [ -n "$project_id" ]; then
+    set_policies_command="${set_policies_command} --project-id ${project_id}"
+  fi
+
+  if [ -n "$custom_policies_path" ]; then
+    set_policies_command="${set_policies_command} $custom_policies_path"
+  fi
+}
+
+buildClearPoliciesCommand() {
+  clear_policies_command="spotter clear-policies"
+
+  if [ -n "$project_id" ]; then
+    clear_policies_command="${clear_policies_command} --project-id ${project_id}"
+  fi
+}
 
 buildScanCLICommand() {
   scan_command="spotter scan"
@@ -46,8 +69,18 @@ buildScanCLICommand() {
   fi
 }
 
-# construct the CLI command
+# construct CLI commands
+buildSetPoliciesCommand
 buildScanCLICommand
+buildClearPoliciesCommand
 
-# run the CLI command
-${scan_command}
+# run CLI commands
+if [ -n "$custom_policies_path" ]; then
+  ${set_policies_command}
+  ${scan_command}
+  if [ "$custom_policies_clear" = "true" ]; then
+    ${clear_policies_command}
+  fi
+else
+  ${scan_command}
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,11 +3,12 @@
 # set CLI arguments
 paths="$1"
 project_id="$2"
-upload_values="$3"
-upload_metadata="$4"
+include_values="$3"
+include_metadata="$4"
 display_level="$5"
 no_docs_url="$6"
 ansible_version="$7"
+profile="$8"
 
 buildScanCLICommand() {
   scan_command="spotter scan"
@@ -16,12 +17,12 @@ buildScanCLICommand() {
     scan_command="${scan_command} --project-id ${project_id}"
   fi
 
-  if [ "$upload_values" = "true" ]; then
-    scan_command="${scan_command} --upload-values"
+  if [ "$include_values" = "true" ]; then
+    scan_command="${scan_command} --include-values"
   fi
 
-  if [ "$upload_metadata" = "true" ]; then
-    scan_command="${scan_command} --upload-metadata"
+  if [ "$include_metadata" = "true" ]; then
+    scan_command="${scan_command} --include-metadata"
   fi
 
   if [ -n "$display_level" ]; then
@@ -33,7 +34,11 @@ buildScanCLICommand() {
   fi
 
   if [ -n "$ansible_version" ]; then
-    scan_command="${scan_command} --option ansible_version=${ansible_version}"
+    scan_command="${scan_command} --ansible-version ${ansible_version}"
+  fi
+
+  if [ -n "$profile" ]; then
+    scan_command="${scan_command} --profile ${profile}"
   fi
 
   if [ -n "$paths" ]; then


### PR DESCRIPTION
The following PR brings important additions to the current Spotter GH Action.

The changes here are the following:

- use Spotter CLI version [1.2.6](https://pypi.org/project/steampunk-spotter/1.2.6/);
- update action options in `action.yml` and `entrypoint.sh` to follow up the changes in CLI flags (use include- instead of upload-, introduce scan profiles, remove --option ansible_version=x.y);
- support for setting and clearing custom OPA policies written in Rego Language (this is an enterprise feature for now);
- update integration tests to use the latest changes;
- describe the latest changes in README.