### PR TITLE
CLI to 1.2.7, input support for global flags and skipping checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Run Ansible scan with different inputs
         uses: ./
         with:
+          endpoint: https://api.spotter.steampunk.si/api
+          api_token: ${{ secrets.SPOTTER_API_TOKEN }}
           paths: tests/playbook-with-errors.yml
           include_values: true
           include_metadata: true
@@ -23,8 +25,21 @@ jobs:
           no_docs_url: true
           ansible_version: 2.14
           profile: full
+          skip_checks: E001,E1300
+        continue-on-error: true
+
+      - name: Run Ansible scan with username and password (old auth method, without env vars)
+        uses: ./
+        with:
+          username: ${{ secrets.SPOTTER_USERNAME }}
+          password: ${{ secrets.SPOTTER_PASSWORD }}
+        continue-on-error: true
+
+      - name: Run Ansible scan with username and password (old auth method, with env vars)
+        uses: ./
         env:
-          SPOTTER_API_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
+          SPOTTER_USERNAME: ${{ secrets.SPOTTER_USERNAME }}
+          SPOTTER_PASSWORD: ${{ secrets.SPOTTER_PASSWORD }}
         continue-on-error: true
 
       - name: Run Ansible scan without errors
@@ -35,10 +50,3 @@ jobs:
           display_level: error
         env:
           SPOTTER_API_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
-
-      - name: Run Ansible scan with username and password (old auth method)
-        uses: ./
-        env:
-          SPOTTER_USERNAME: ${{ secrets.SPOTTER_USERNAME }}
-          SPOTTER_PASSWORD: ${{ secrets.SPOTTER_PASSWORD }}
-        continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.2.6
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.2.7
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,19 @@ The action accepts the following inputs:
 
 | Name                    | Required | Default | Description                                                                                                                                                                        |
 |-------------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `endpoint`              | no       | /       | Steampunk Spotter API endpoint (instead of default https://api.spotter.steampunk.si/api).                                                                                          |
+| `api_token`             | no       | /       | Steampunk Spotter API token (can be generated in the user settings within the Spotter App).                                                                                        |
+| `username`              | no       | /       | Steampunk Spotter username (this is an old auth method, use API token if possible).                                                                                                |
+| `password`              | no       | /       | Steampunk Spotter password (this is an old auth method, use API token if possible).                                                                                                |
 | `paths`                 | no       | .       | List of paths to Ansible content files to be scanned. If not specified, the whole repository is scanned.                                                                           |
 | `project_id`            | no       | /       | ID of an existing target project in the app, where the scan result will be stored. If not specified, the first project of the user's first organization (in the app) will be used. |
-| `upload_values`         | no       | false   | Parses and uploads values from Ansible task parameters to the backend.                                                                                                             |                                
-| `upload_metadata`       | no       | false   | Uploads metadata (i.e., file names, line and column numbers) to the backend.                                                                                                       |                                
+| `upload_values`         | no       | false   | Parses and uploads values from Ansible task parameters to the backend.                                                                                                             |
+| `upload_metadata`       | no       | false   | Uploads metadata (i.e., file names, line and column numbers) to the backend.                                                                                                       |
 | `display_level`         | no       | hint    | Displays check results with specified level or greater (e.g., warning will show all warnings and errors, but suppress hints). Available options: hint, warning, error.             |
-| `no_docs_url`           | no       | false   | Omits documentation URLs from the output.                                                                                                                                          |  
+| `no_docs_url`           | no       | false   | Omits documentation URLs from the output.                                                                                                                                          |
 | `ansible_version`       | no       | /       | Ansible version to use for scanning. If not specified, all Ansible versions are considered for scanning.                                                                           |
 | `profile`               | no       | /       | Sets profile with selected set of checks to be used for scanning.                                                                                                                  |
+| `skip_checks`           | no       | /       | Skips checks with specified IDs. IDs should be comma-separated, space-separated or newline-separated and can be found in the check catalog withing the Spotter App.                |
 | `custom_policies_path`  | no       | /       | Path to the file or folder with custom OPA policies written in Rego Language (enterprise feature).                                                                                 |
 | `custom_policies_clear` | no       | /       | Clears OPA policies for custom Spotter checks after scanning (enterprise feature).                                                                                                 |
 
@@ -57,7 +62,9 @@ The action produces the following outputs:
 ### Environment variables
 The action will take into account the following environment variables:
 
-* `SPOTTER_API_TOKEN`: Steampunk Spotter API token (can be generated in the 
+* `SPOTTER_ENDPOINT`: Steampunk Spotter API endpoint (instead of default
+  https://api.spotter.steampunk.si/api).
+* `SPOTTER_API_TOKEN`: Steampunk Spotter API token (can be generated in the
    user settings within the Spotter App);
 * `SPOTTER_USERNAME`: Steampunk Spotter username;
 * `SPOTTER_PASSWORD`: Steampunk Spotter password.
@@ -98,6 +105,8 @@ jobs:
       - name: Scan Ansible content with different inputs
         uses: xlab-steampunk/spotter-action@<version>
         with:
+          endpoint: https://api.spotter.steampunk.si/api
+          api_token: ${{ secrets.SPOTTER_API_TOKEN }}
           paths: playbook.yaml
           include_values: true
           include_metadata: true
@@ -105,8 +114,7 @@ jobs:
           no_docs_url: true
           ansible_version: 2.14
           profile: full
-        env:
-          SPOTTER_API_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
+          skip_checks: E001,E1300
 ```
 
 ## Acknowledgement

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,22 @@
 name: "Steampunk Spotter"
-description: "Scan your Ansible content using Steampunk Spotter."
+description: "Steampunk Spotter provides an Ansible Playbook Scanning Tool that analyzes and offers recommendations for your Ansible Playbooks."
 author: "XLAB Steampunk"
 branding:
   icon: "target"
   color: "red"
 inputs:
+  endpoint:
+    description: "Steampunk Spotter API endpoint (instead of default https://api.spotter.steampunk.si/api)."
+    required: false
+  api_token:
+    description: "Steampunk Spotter API token."
+    required: false
+  username:
+    description: "Steampunk Spotter username."
+    required: false
+  password:
+    description: "Steampunk Spotter password."
+    required: false
   paths:
     description: "List of paths to Ansible content files to be scanned. If not specified, the whole repository is scanned."
     required: false
@@ -35,6 +47,9 @@ inputs:
     description: "Sets profile with selected set of checks to be used for scanning."
     required: false
     default: "default"
+  skip_checks:
+    description: "Skips checks with specified IDs."
+    required: false
   custom_policies_path:
     description: "Path to the file or folder with custom OPA policies written in Rego Language (enterprise feature)."
     required: false
@@ -49,6 +64,10 @@ runs:
   using: "docker"
   image: "docker://ghcr.io/xlab-steampunk/spotter-action:latest"
   args:
+    - ${{ inputs.endpoint }}
+    - ${{ inputs.api_token }}
+    - ${{ inputs.username }}
+    - ${{ inputs.password }}
     - ${{ inputs.paths }}
     - ${{ inputs.project_id }}
     - ${{ inputs.include_values }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,43 @@
 #!/bin/sh
 
 # set CLI arguments
-paths="$1"
-project_id="$2"
-include_values="$3"
-include_metadata="$4"
-display_level="$5"
-no_docs_url="$6"
-ansible_version="$7"
-profile="$8"
-custom_policies_path="$9"
-custom_policies_clear="${10}"
+endpoint="$1"
+api_token="$2"
+username="$3"
+password="$4"
+paths="$5"
+project_id="$6"
+include_values="$7"
+include_metadata="$8"
+display_level="$9"
+no_docs_url="${10}"
+ansible_version="${11}"
+profile="${12}"
+skip_checks="${13}"
+custom_policies_path="${14}"
+custom_policies_clear="${15}"
 
-# helper functions for building CLI commands
+# build global Spotter CLI command
+global_spotter_command="spotter"
+if [ -n "$endpoint" ]; then
+  global_spotter_command="${global_spotter_command} --endpoint ${endpoint}"
+fi
+
+if [ -n "$api_token" ]; then
+  global_spotter_command="${global_spotter_command} --api-token ${api_token}"
+fi
+
+if [ -n "$username" ]; then
+  global_spotter_command="${global_spotter_command} --username ${username}"
+fi
+
+if [ -n "$password" ]; then
+  global_spotter_command="${global_spotter_command} --password ${password}"
+fi
+
+# helper functions for building CLI subcommands
 buildSetPoliciesCommand() {
-  set_policies_command="spotter set-policies"
+  set_policies_command="${global_spotter_command} set-policies"
 
   if [ -n "$project_id" ]; then
     set_policies_command="${set_policies_command} --project-id ${project_id}"
@@ -26,7 +49,7 @@ buildSetPoliciesCommand() {
 }
 
 buildClearPoliciesCommand() {
-  clear_policies_command="spotter clear-policies"
+  clear_policies_command="${global_spotter_command} clear-policies"
 
   if [ -n "$project_id" ]; then
     clear_policies_command="${clear_policies_command} --project-id ${project_id}"
@@ -34,7 +57,7 @@ buildClearPoliciesCommand() {
 }
 
 buildScanCLICommand() {
-  scan_command="spotter scan"
+  scan_command="${global_spotter_command} scan"
 
   if [ "$project_id" = "true" ]; then
     scan_command="${scan_command} --project-id ${project_id}"
@@ -62,6 +85,12 @@ buildScanCLICommand() {
 
   if [ -n "$profile" ]; then
     scan_command="${scan_command} --profile ${profile}"
+  fi
+
+  if [ -n "$skip_checks" ]; then
+    skip_checks=$(printf "%s" "$skip_checks" | tr "\n" ",")
+    set -- "${scan_command}" "--skip-checks" "\"""${skip_checks}""\""
+    scan_command="$*"
   fi
 
   if [ -n "$paths" ]; then


### PR DESCRIPTION
This will update our Spotter GH Action with the following things:

- upgrade Spotter CLI Docker image tag to the one that uses Spotter CLI version [1.2.7](https://pypi.org/project/steampunk-spotter/1.2.6/);
- add new global inputs (endpoint, API token, username, and password) that support global Spotter CLI flags (this will enable setting those values directly with the action and without the need to export env vars in the action pipeline);
- support skipping checks feature;
- update integration tests to explain and use new functionalities;
- update README to explain and use new functionalities.