### PR TITLE
Add missing skip_checks Dockerfile argument to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,5 +76,6 @@ runs:
     - ${{ inputs.no_docs_url }}
     - ${{ inputs.ansible_version }}
     - ${{ inputs.profile }}
+    - ${{ inputs.skip_checks }}
     - ${{ inputs.custom_policies_path }}
     - ${{ inputs.custom_policies_clear }}


### PR DESCRIPTION
There was a bug in the action because of a missing `skip_checks` input from Dockerfile arguments in `action.yml` file. This will resolve the issue and the action should now behave normally.