### PR TITLE
Bump CLI Docker image tag to 1.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.2.7
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.2.8
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
This change will upgrade the Spotter CLI to version `1.2.8`.