### PR TITLE
Bump Spotter CLI Docker image tag to 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:1.2.8
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.0.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
We just hit a new milestone - [Steampunk Spotter](https://steampunk.si/spotter/) `2.0` is officially out!

This change will upgrade the [Spotter CLI](https://gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli) version to [`2.0.0`](https://pypi.org/project/steampunk-spotter/2.0.0/) for our GitHub Action.