### PR TITLE
Bump Spotter CLI to 2.1.0 and support enforcing checks and setting config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           endpoint: https://api.spotter.steampunk.si/api
           api_token: ${{ secrets.SPOTTER_API_TOKEN }}
+          config: tests/config.yml
           paths: tests/playbook-with-errors.yml
           include_values: true
           include_metadata: true
@@ -25,7 +26,8 @@ jobs:
           no_docs_url: true
           ansible_version: 2.14
           profile: full
-          skip_checks: E001,E1300
+          skip_checks: E001,E903[fqcn=sensu.sensu_go.user]
+          enforce_checks: E1300,E1301
         continue-on-error: true
 
       - name: Run Ansible scan with username and password (old auth method, without env vars)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.0.0
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.1.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The action accepts the following inputs:
 | `api_token`             | no       | /       | Steampunk Spotter API token (can be generated in the user settings within the Spotter App).                                                                                        |
 | `username`              | no       | /       | Steampunk Spotter username (this is an old auth method, use API token if possible).                                                                                                |
 | `password`              | no       | /       | Steampunk Spotter password (this is an old auth method, use API token if possible).                                                                                                |
+| `config`                | no       | /       | Path to JSON/YAML configuration file.                                                                                                                                              |
 | `paths`                 | no       | .       | List of paths to Ansible content files to be scanned. If not specified, the whole repository is scanned.                                                                           |
 | `project_id`            | no       | /       | ID of an existing target project in the app, where the scan result will be stored. If not specified, the first project of the user's first organization (in the app) will be used. |
 | `upload_values`         | no       | false   | Parses and uploads values from Ansible task parameters to the backend.                                                                                                             |
@@ -50,7 +51,8 @@ The action accepts the following inputs:
 | `no_docs_url`           | no       | false   | Omits documentation URLs from the output.                                                                                                                                          |
 | `ansible_version`       | no       | /       | Ansible version to use for scanning. If not specified, all Ansible versions are considered for scanning.                                                                           |
 | `profile`               | no       | /       | Sets profile with selected set of checks to be used for scanning.                                                                                                                  |
-| `skip_checks`           | no       | /       | Skips checks with specified IDs. IDs should be comma-separated, space-separated or newline-separated and can be found in the check catalog withing the Spotter App.                |
+| `skip_checks`           | no       | /       | Skips checks with specified IDs. IDs should be comma-separated, space-separated or newline-separated and can be found in the check catalog within the Spotter App.                 |
+| `enforce_checks`        | no       | /       | Enforce checks with specified IDs. IDs should be comma-separated, space-separated or newline-separated and can be found in the check catalog within the Spotter App.               |
 | `custom_policies_path`  | no       | /       | Path to the file or folder with custom OPA policies written in Rego Language (enterprise feature).                                                                                 |
 | `custom_policies_clear` | no       | /       | Clears OPA policies for custom Spotter checks after scanning (enterprise feature).                                                                                                 |
 
@@ -107,6 +109,7 @@ jobs:
         with:
           endpoint: https://api.spotter.steampunk.si/api
           api_token: ${{ secrets.SPOTTER_API_TOKEN }}
+          config: config.yaml
           paths: playbook.yaml
           include_values: true
           include_metadata: true
@@ -114,7 +117,8 @@ jobs:
           no_docs_url: true
           ansible_version: 2.14
           profile: full
-          skip_checks: E001,E1300
+          skip_checks: E001,E903[fqcn=sensu.sensu_go.user]
+          enforce_checks: E1300,E1301
 ```
 
 ## Acknowledgement

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   password:
     description: "Steampunk Spotter password."
     required: false
+  config:
+    description: "Path to JSON/YAML configuration file."
+    required: false
   paths:
     description: "List of paths to Ansible content files to be scanned. If not specified, the whole repository is scanned."
     required: false
@@ -50,6 +53,9 @@ inputs:
   skip_checks:
     description: "Skips checks with specified IDs."
     required: false
+  enforce_checks:
+    description: "Enforce checks with specified IDs."
+    required: false
   custom_policies_path:
     description: "Path to the file or folder with custom OPA policies written in Rego Language (enterprise feature)."
     required: false
@@ -68,6 +74,7 @@ runs:
     - ${{ inputs.api_token }}
     - ${{ inputs.username }}
     - ${{ inputs.password }}
+    - ${{ inputs.config }}
     - ${{ inputs.paths }}
     - ${{ inputs.project_id }}
     - ${{ inputs.include_values }}
@@ -77,5 +84,6 @@ runs:
     - ${{ inputs.ansible_version }}
     - ${{ inputs.profile }}
     - ${{ inputs.skip_checks }}
+    - ${{ inputs.enforce_checks }}
     - ${{ inputs.custom_policies_path }}
     - ${{ inputs.custom_policies_clear }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,17 +5,19 @@ endpoint="$1"
 api_token="$2"
 username="$3"
 password="$4"
-paths="$5"
-project_id="$6"
-include_values="$7"
-include_metadata="$8"
-display_level="$9"
-no_docs_url="${10}"
-ansible_version="${11}"
-profile="${12}"
-skip_checks="${13}"
-custom_policies_path="${14}"
-custom_policies_clear="${15}"
+config="$5"
+paths="$6"
+project_id="$7"
+include_values="$8"
+include_metadata="$9"
+display_level="${10}"
+no_docs_url="${11}"
+ansible_version="${12}"
+profile="${13}"
+skip_checks="${14}"
+enforce_checks="${15}"
+custom_policies_path="${16}"
+custom_policies_clear="${17}"
 
 # build global Spotter CLI command
 global_spotter_command="spotter"
@@ -59,6 +61,10 @@ buildClearPoliciesCommand() {
 buildScanCLICommand() {
   scan_command="${global_spotter_command} scan"
 
+  if [ "$config" = "true" ]; then
+    scan_command="${scan_command} --config ${config}"
+  fi
+
   if [ "$project_id" = "true" ]; then
     scan_command="${scan_command} --project-id ${project_id}"
   fi
@@ -90,6 +96,12 @@ buildScanCLICommand() {
   if [ -n "$skip_checks" ]; then
     skip_checks=$(printf "%s" "$skip_checks" | tr "\n" ",")
     set -- "${scan_command}" "--skip-checks" "\"""${skip_checks}""\""
+    scan_command="$*"
+  fi
+
+  if [ -n "$enforce_checks" ]; then
+    enforce_checks=$(printf "%s" "$enforce_checks" | tr "\n" ",")
+    set -- "${scan_command}" "--enforce-checks" "\"""${enforce_checks}""\""
     scan_command="$*"
   fi
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,5 @@
+skip_checks:
+  - event: E901
+    fqcn: sensu.sensu_go.user
+enforce_checks:
+  - event: W400


### PR DESCRIPTION
The changes here will:

- upgrade Steampunk Spotter CLI to version `2.1.0`;
- support `enforce_checks` and `config` action inputs;
- enhance integration tests according to the changes;
- update README according to the changes.