### PR TITLE
Update Docker image tag from action.yml on tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,17 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}
 
+      - name: Update action.yml
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: fjogeleit/yaml-update-action@main
+        with:
+          valueFile: action.yml
+          propertyPath: runs.image
+          value: docker://ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}
+          commitChange: true
+          targetBranch: ${{ steps.vars.outputs.tag }}
+          message: Use ${{ steps.vars.outputs.tag }} Docker image tag in action.yml
+
       - name: Draft a new GitHub release (for tags)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
These changes will make sure that on every new tag push the `latest` Spotter action Docker image tag from `action.yml ` will be replaced by the tag of the newly created Spotter action Docker image tag.

The CI/CD and the release process now goes like this:

- we update Spotter CLI's Docker image in `Dockerfile` when a new Spotter CLI gets released;
- on a pull request, we should build the Spotter action Docker image with changes and test the action;
- the master branch keeps using the latest Spotter action Docker image tag;
- on the tag branch we build and push a new Spotter action Docker image with the same tag;
- then the latest Spotter Docker image tag from `action.yml` is replaced by the tag of the newly created Docker image tag;     
- after that, the Spotter action is be ready to be released.
