### PR TITLE
Upgrade Spotter CLI Docker image to version 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.1.0
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.2.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
This will make sure that Spotter GH Action uses the latest Spotter CLI version [`2.2.0`](https://pypi.org/project/steampunk-spotter/2.2.0/).