### PR TITLE
Fix use of yaml-update-action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,7 @@ jobs:
           propertyPath: runs.image
           value: docker://ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}
           commitChange: true
+          createPR: false
           branch: ${{ steps.vars.outputs.tag }}
           message: Use ${{ steps.vars.outputs.tag }} Docker image tag in action.yml
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
           propertyPath: runs.image
           value: docker://ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}
           commitChange: true
-          targetBranch: ${{ steps.vars.outputs.tag }}
+          branch: ${{ steps.vars.outputs.tag }}
           message: Use ${{ steps.vars.outputs.tag }} Docker image tag in action.yml
 
       - name: Draft a new GitHub release (for tags)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,9 +43,9 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}
 
-      - name: Update action.yml
+      - name: Update action.yml (for tags)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: fjogeleit/yaml-update-action@main
+        uses: fjogeleit/yaml-update-action@v0.13.1
         with:
           valueFile: action.yml
           propertyPath: runs.image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,7 @@ jobs:
           valueFile: action.yml
           propertyPath: runs.image
           value: docker://ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}
+          quotingType: '"'
           commitChange: true
           createPR: false
           branch: ${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
After implementing `action.yml` updates on tag push by using [fjogeleit/yaml-update-action](https://github.com/fjogeleit/yaml-update-action) in #16 we still need to fix some of the action inputs so it will work in the right way for us. This includes:

- using the latest stable version `v0.13.1` of the action like we do for other actions;
- use `branch` input instead of `targetBranch` to achieve committing to the tag branch;
- setting `createPR` to `false` explicitly to prevent opening a new PR from `branch` to `targetBranch`;
- seting `quotingType` to `"` because this is the one we use.