### PR TITLE
Make uploading values and metadata opt-out, bump CLI to 2.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
           api_token: ${{ secrets.SPOTTER_API_TOKEN }}
           config: tests/config.yml
           paths: tests/playbook-with-errors.yml
-          include_values: true
-          include_metadata: true
+          exclude_values: true
+          exclude_metadata: true
           display_level: error
           no_docs_url: true
           ansible_version: 2.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.2.0
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.3.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The action accepts the following inputs:
 | `config`                | no       | /       | Path to JSON/YAML configuration file.                                                                                                                                              |
 | `paths`                 | no       | .       | List of paths to Ansible content files to be scanned. If not specified, the whole repository is scanned.                                                                           |
 | `project_id`            | no       | /       | ID of an existing target project in the app, where the scan result will be stored. If not specified, the first project of the user's first organization (in the app) will be used. |
-| `upload_values`         | no       | false   | Parses and uploads values from Ansible task parameters to the backend.                                                                                                             |
-| `upload_metadata`       | no       | false   | Uploads metadata (i.e., file names, line and column numbers) to the backend.                                                                                                       |
+| `exclude_values`        | no       | false   | Omits parsing and uploading values from Ansible playbooks.                                                                                                                         |
+| `exclude_metadata`      | no       | false   | Omits collecting and uploading metadata (i.e., file names, line and column numbers).                                                                                               |
 | `display_level`         | no       | hint    | Displays check results with specified level or greater (e.g., warning will show all warnings and errors, but suppress hints). Available options: hint, warning, error.             |
 | `no_docs_url`           | no       | false   | Omits documentation URLs from the output.                                                                                                                                          |
 | `ansible_version`       | no       | /       | Ansible version to use for scanning. If not specified, all Ansible versions are considered for scanning.                                                                           |
@@ -111,8 +111,8 @@ jobs:
           api_token: ${{ secrets.SPOTTER_API_TOKEN }}
           config: config.yaml
           paths: playbook.yaml
-          include_values: true
-          include_metadata: true
+          exclude_values: true
+          exclude_metadata: true
           display_level: error
           no_docs_url: true
           ansible_version: 2.14

--- a/action.yml
+++ b/action.yml
@@ -27,12 +27,12 @@ inputs:
   project_id:
     description: "ID of an existing target project in the app, where the scan result will be stored. If not specified, the first project of the user's first organization (in the app) will be used."
     required: false
-  include_values:
-    description: "Parses and uploads values from Ansible task parameters to the backend."
+  exclude_values:
+    description: "Omits parsing and uploading values from Ansible playbooks."
     required: false
     default: "false"
-  include_metadata:
-    description: "Uploads metadata (i.e., file names, line and column numbers) to the backend."
+  exclude_metadata:
+    description: "Omits collecting and uploading metadata (i.e., file names, line and column numbers)."
     required: false
     default: "false"
   display_level:
@@ -77,8 +77,8 @@ runs:
     - ${{ inputs.config }}
     - ${{ inputs.paths }}
     - ${{ inputs.project_id }}
-    - ${{ inputs.include_values }}
-    - ${{ inputs.include_metadata }}
+    - ${{ inputs.exclude_values }}
+    - ${{ inputs.exclude_metadata }}
     - ${{ inputs.display_level }}
     - ${{ inputs.no_docs_url }}
     - ${{ inputs.ansible_version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,8 @@ password="$4"
 config="$5"
 paths="$6"
 project_id="$7"
-include_values="$8"
-include_metadata="$9"
+exclude_values="$8"
+exclude_metadata="$9"
 display_level="${10}"
 no_docs_url="${11}"
 ansible_version="${12}"
@@ -69,12 +69,12 @@ buildScanCLICommand() {
     scan_command="${scan_command} --project-id ${project_id}"
   fi
 
-  if [ "$include_values" = "true" ]; then
-    scan_command="${scan_command} --include-values"
+  if [ "$exclude_values" = "true" ]; then
+    scan_command="${scan_command} --exclude-values"
   fi
 
-  if [ "$include_metadata" = "true" ]; then
-    scan_command="${scan_command} --include-metadata"
+  if [ "$exclude_metadata" = "true" ]; then
+    scan_command="${scan_command} --exclude-metadata"
   fi
 
   if [ -n "$display_level" ]; then


### PR DESCRIPTION
The latest Spotter CLI includes a big change that will allow us to provide better and more results to the user when scanning Ansible playbooks. Metadata and values are now collected and transmitted to the backend by default. The user may opt out of this behavior using `--exclude-metadata` and `--exclude-values`, respectively.

So, the changes here do the following:

- bump Spotter CLI Docker image to the latest version `2.3.0`;
- use `--exclude-values` and `--exclude-metadata` instead of --include flags in `entrypoint.sh`;
- add `exclude_values` and `exclude_metadata` action inputs and remove include_ inputs;
- document the exclude_ inputs in README;
- use exclude_ inputs in integration tests.