### PR TITLE
Use --no-progress/color and upgrade Spotter CLI to 2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.3.0
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.4.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ custom_policies_path="${16}"
 custom_policies_clear="${17}"
 
 # build global Spotter CLI command
-global_spotter_command="spotter"
+global_spotter_command="spotter --no-color"
 if [ -n "$endpoint" ]; then
   global_spotter_command="${global_spotter_command} --endpoint ${endpoint}"
 fi
@@ -59,7 +59,7 @@ buildClearPoliciesCommand() {
 }
 
 buildScanCLICommand() {
-  scan_command="${global_spotter_command} scan"
+  scan_command="${global_spotter_command} scan --no-progress"
 
   if [ "$config" = "true" ]; then
     scan_command="${scan_command} --config ${config}"


### PR DESCRIPTION
With these changes, we make sure that we use the `--no-color` and `--no-progress` CLI options in `entrypoint.sh`. We also upgraded the Spotter CLI to the latest `2.4.0`.