### PR TITLE
Upgrade action versions in CI/CD

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,15 +6,15 @@ jobs:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -23,7 +23,7 @@ jobs:
       - name: Build and push (for master branch)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         id: docker_build_master
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
           push: true
@@ -37,7 +37,7 @@ jobs:
       - name: Build and push (for tags)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         id: docker_build_tag
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Ansible scan with minimal possible example
         uses: ./


### PR DESCRIPTION
These changes will upgrade versions (to their latest versions) of actions used within our GitHub Actions CI/CD workflow.

This is also needed because our `docker` workflow started [failing](https://github.com/xlab-steampunk/spotter-action/actions/runs/6349934157).

The changes were tested locally with [act](https://github.com/nektos/act).