### PR TITLE
Bump Spotter CLI version to 2.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.4.0
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.5.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
The changes here will bump the Spotter CLI Docker image to the latest version [`2.5.0`](https://pypi.org/project/steampunk-spotter/2.5.0/).