### PR TITLE
Integrate with Spotter CLI version 3.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Run Ansible scan with minimal possible example
         uses: ./
         env:
-          SPOTTER_API_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
+          SPOTTER_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
         continue-on-error: true
 
       - name: Run Ansible scan with different inputs
@@ -51,4 +51,4 @@ jobs:
           ansible_version: 2.16
           display_level: error
         env:
-          SPOTTER_API_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
+          SPOTTER_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:2.6.0
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:3.0.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ The action will take into account the following environment variables:
 
 * `SPOTTER_ENDPOINT`: Steampunk Spotter API endpoint (instead of default
   https://api.spotter.steampunk.si/api).
-* `SPOTTER_API_TOKEN`: Steampunk Spotter API token (can be generated in the
+* `SPOTTER_TOKEN`: Steampunk Spotter API token (can be generated in the
    user settings within the Spotter App);
 * `SPOTTER_USERNAME`: Steampunk Spotter username;
 * `SPOTTER_PASSWORD`: Steampunk Spotter password.
 
-We encourage you to authenticate by setting `SPOTTER_API_TOKEN` instead of old
+We encourage you to authenticate by setting `SPOTTER_TOKEN` instead of old
 `SPOTTER_USERNAME` and `SPOTTER_PASSWORD` environment variables.
 
 ### Examples
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: xlab-steampunk/spotter-action@<version>
         env:
-          SPOTTER_API_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
+          SPOTTER_TOKEN: ${{ secrets.SPOTTER_TOKEN }}
 ```
 
 A more complex example with multiple action inputs is the following:
@@ -111,7 +111,7 @@ jobs:
         uses: xlab-steampunk/spotter-action@<version>
         with:
           endpoint: https://api.spotter.steampunk.si/api
-          api_token: ${{ secrets.SPOTTER_API_TOKEN }}
+          api_token: ${{ secrets.SPOTTER_TOKEN }}
           config: config.yaml
           paths: playbook.yaml
           exclude_values: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ if [ -n "$endpoint" ]; then
 fi
 
 if [ -n "$api_token" ]; then
-  global_spotter_command="${global_spotter_command} --api-token ${api_token}"
+  global_spotter_command="${global_spotter_command} --token ${api_token}"
 fi
 
 if [ -n "$username" ]; then
@@ -43,24 +43,26 @@ if [ -n "$timeout" ]; then
 fi
 
 # helper functions for building CLI subcommands
-buildSetPoliciesCommand() {
-  set_policies_command="${global_spotter_command} set-policies"
+buildPoliciesCommand() {
+  policies_command="${global_spotter_command} policies"
 
   if [ -n "$project_id" ]; then
-    set_policies_command="${set_policies_command} --project-id ${project_id}"
-  fi
-
-  if [ -n "$custom_policies_path" ]; then
-    set_policies_command="${set_policies_command} $custom_policies_path"
+    policies_command="${policies_command} --project-id ${project_id}"
   fi
 }
 
-buildClearPoliciesCommand() {
-  clear_policies_command="${global_spotter_command} clear-policies"
+buildPoliciesSetCommand() {
+  buildPoliciesCommand
+  policies_set_command="${policies_command} set"
 
-  if [ -n "$project_id" ]; then
-    clear_policies_command="${clear_policies_command} --project-id ${project_id}"
+  if [ -n "$custom_policies_path" ]; then
+    policies_set_command="${policies_set_command} $custom_policies_path"
   fi
+}
+
+buildPoliciesClearCommand() {
+  buildPoliciesCommand
+  policies_clear_command="${policies_command} clear"
 }
 
 buildScanCLICommand() {
@@ -116,16 +118,16 @@ buildScanCLICommand() {
 }
 
 # construct CLI commands
-buildSetPoliciesCommand
+buildPoliciesSetCommand
 buildScanCLICommand
-buildClearPoliciesCommand
+buildPoliciesClearCommand
 
 # run CLI commands
 if [ -n "$custom_policies_path" ]; then
-  ${set_policies_command}
+  ${policies_set_command}
   ${scan_command}
   if [ "$custom_policies_clear" = "true" ]; then
-    ${clear_policies_command}
+    ${policies_clear_command}
   fi
 else
   ${scan_command}


### PR DESCRIPTION
With the following changes, we aim to support the latest Spotter CLI version [`3.0.0`](https://pypi.org/project/steampunk-spotter/3.0.0/):

- build GH Action Docker image from Spotter CLI Docker image with tag `3.0.0`;
- use latest CLI features in `entrypoint.sh`;
- update integration tests to use latest CLI features;
- document action changes for version 3.0.0 in README.