### PR TITLE
Bump Spotter CLI Docker image tag to 3.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,12 @@ jobs:
           display_level: error
         env:
           SPOTTER_TOKEN: ${{ secrets.SPOTTER_API_TOKEN }}
+
+      - name: Run Ansible scan with debug
+        uses: ./
+        with:
+          endpoint: https://api.spotter.steampunk.si/api
+          api_token: ${{ secrets.SPOTTER_API_TOKEN }}
+          paths: tests/playbook-no-errors.yml
+          debug: true
+        continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:3.1.0
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:3.1.1
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The action accepts the following inputs:
 | `enforce_checks`        | no       | /       | Enforce checks with specified IDs. IDs should be comma-separated, space-separated or newline-separated and can be found in the check catalog within the Spotter App.               |
 | `custom_policies_path`  | no       | /       | Path to the file or folder with custom OPA policies written in Rego Language (enterprise feature).                                                                                 |
 | `custom_policies_clear` | no       | /       | Clears OPA policies for custom Spotter checks after scanning (enterprise feature).                                                                                                 |
+| `debug`                 | no       | /       | Enable debug output.                                                                                                                                                               |
 
 ### Outputs
 The action produces the following outputs:
@@ -123,6 +124,7 @@ jobs:
           profile: full
           skip_checks: E001,E903[fqcn=sensu.sensu_go.user]
           enforce_checks: E1300,E1301
+          debug: true
 ```
 
 ### Next steps

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,9 @@ inputs:
     description: "Clears OPA policies for custom Spotter checks after scanning (enterprise feature)."
     required: false
     default: "false"
+  debug:
+    description: "Enable debug output."
+    required: false
 outputs:
   output:
     description: "Output from scanning (from spotter scan CLI command)."
@@ -82,6 +85,7 @@ runs:
     - ${{ inputs.username }}
     - ${{ inputs.password }}
     - ${{ inputs.timeout }}
+    - ${{ inputs.debug }}
     - ${{ inputs.config }}
     - ${{ inputs.paths }}
     - ${{ inputs.project_id }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,20 +6,21 @@ api_token="$2"
 username="$3"
 password="$4"
 timeout="$5"
-config="$6"
-paths="$7"
-project_id="$8"
-exclude_values="$9"
-exclude_metadata="${10}"
-display_level="${11}"
-no_docs_url="${12}"
-no_scan_url="${13}"
-ansible_version="${14}"
-profile="${15}"
-skip_checks="${16}"
-enforce_checks="${17}"
-custom_policies_path="${18}"
-custom_policies_clear="${19}"
+debug="$6"
+config="$7"
+paths="$8"
+project_id="$9"
+exclude_values="${10}"
+exclude_metadata="${11}"
+display_level="${12}"
+no_docs_url="${13}"
+no_scan_url="${14}"
+ansible_version="${15}"
+profile="${16}"
+skip_checks="${17}"
+enforce_checks="${18}"
+custom_policies_path="${19}"
+custom_policies_clear="${20}"
 
 # build global Spotter CLI command
 global_spotter_command="spotter --no-color"
@@ -41,6 +42,10 @@ fi
 
 if [ -n "$timeout" ]; then
   global_spotter_command="${global_spotter_command} --timeout ${timeout}"
+fi
+
+if [ "$debug" = "true" ]; then
+  global_spotter_command="${global_spotter_command} --debug"
 fi
 
 # helper functions for building CLI subcommands


### PR DESCRIPTION
Upgrading Spotter CLI to the version `3.1.1`.