### PR TITLE
Bugfix for unused project_id and config inputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:3.2.0
+FROM registry.gitlab.com/xlab-steampunk/steampunk-spotter-client/spotter-cli:3.3.0
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,11 +75,11 @@ buildPoliciesClearCommand() {
 buildScanCLICommand() {
   scan_command="${global_spotter_command} scan --origin ci --no-progress"
 
-  if [ "$config" = "true" ]; then
+  if [ -n "$config" ]; then
     scan_command="${scan_command} --config ${config}"
   fi
 
-  if [ "$project_id" = "true" ]; then
+  if [ -n "$project_id" ]; then
     scan_command="${scan_command} --project-id ${project_id}"
   fi
 


### PR DESCRIPTION
In this MR we:

-  fixed cases where project id was provided but was not read properly. Same goes for config file path.
-  Bumped CLI docker image tag to 3.3.0